### PR TITLE
Changes to enable IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 *.sdf
 *.xap
 obj/
+.vs/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# GenuineChannels Change Log
+
+## v2.5.9.10 (work in progress)
+
+
+### Implementation enhancements:
+
+* IPv6 support (.NET framework version 3.5 and 4.6 only)
+* new parameter **`GenuineParameter.TcpReuseAddressPort`**.
+	  [BOOL] Indicates whether to use TCP port sharing. If set the listener port will be shared (other apps can use the same one).
+        In this case the socket option `System.Net.Sockets.SocketOptionName.ReuseAddress` will be applied. See [MSDN Doc](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socketoptionname?f1url=https%3A%2F%2Fmsdn.microsoft.com%2Fquery%2Fdev15.query%3FappId%3DDev15IDEF1%26l%3DEN-US%26k%3Dk(System.Net.Sockets.SocketOptionName.ReuseAddress);k(vs.objectbrowser);k(TargetFrameworkMoniker-.NETFramework,Version%3Dv4.6)%26rd%3Dtrue&view=netframework-4.7.1 "MSDN Doc").
+        Default value is **false**.
+* new parameter **`GenuineParameter.TcpDualSocketMode`**.
+	  [BOOL] The TCP dual socket mode will enable both IPv4 and IPv6 for the socket listener (Vista and Longhorn above only).
+      This will be **true** by default. If you like to force IPv4 or IPv6 listening only, set this option to false.
+
+
+## v2.5.9.9 (initial github release)

--- a/Genuine Channels/GenuineChannels.Desktop.sln
+++ b/Genuine Channels/GenuineChannels.Desktop.sln
@@ -1,15 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenuineChannels.Desktop.v4.6", "Sources\GenuineChannels.Desktop.v4.6.csproj", "{14FFFF11-DFBE-4F2F-A50E-381DD2DDB7C2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenuineChannels.Desktop.v3.5", "Sources\GenuineChannels.Desktop.v3.5.csproj", "{002F15BE-46E6-47E9-8317-660A0D3CEA3E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenuineChannels.UnitTests", "Tests\GenuineChannels.UnitTests.csproj", "{E2704967-610D-47C5-9A30-73DB8F51394F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenuineChannels.UnitTests.v4.6", "Tests\GenuineChannels.UnitTests.v4.6.csproj", "{E2704967-610D-47C5-9A30-73DB8F51394F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1F34D935-27F1-4D84-8815-E7C693B18F7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenuineChannels.UnitTests.v3.5", "Tests\GenuineChannels.UnitTests.v3.5.csproj", "{E2804967-610D-47C5-1D30-83DB8F61394F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,11 +31,19 @@ Global
 		{E2704967-610D-47C5-9A30-73DB8F51394F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E2704967-610D-47C5-9A30-73DB8F51394F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E2704967-610D-47C5-9A30-73DB8F51394F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2804967-610D-47C5-1D30-83DB8F61394F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2804967-610D-47C5-1D30-83DB8F61394F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2804967-610D-47C5-1D30-83DB8F61394F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2804967-610D-47C5-1D30-83DB8F61394F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E2704967-610D-47C5-9A30-73DB8F51394F} = {1F34D935-27F1-4D84-8815-E7C693B18F7C}
+		{E2804967-610D-47C5-1D30-83DB8F61394F} = {1F34D935-27F1-4D84-8815-E7C693B18F7C}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {978E3691-BCE7-448A-BE0F-0F1EEB07BFAA}
 	EndGlobalSection
 EndGlobal

--- a/Genuine Channels/Sources/GenuineTcp/TcpConnectionManager.cs
+++ b/Genuine Channels/Sources/GenuineTcp/TcpConnectionManager.cs
@@ -2330,7 +2330,8 @@ namespace Belikov.GenuineChannels.GenuineTcp
 			// Prepare dual-mode (IPv4 & IPv6) for the socket listener (Vista and Longhorn above only).
 			// Idea based on http://blogs.msdn.com/wndp/archive/2006/10/24/creating-ip-agnostic-applications-part-2-dual-mode-sockets.aspx
 			AddressFamily addressFamily = ipEndPoint.AddressFamily;
-			if (addressFamily == AddressFamily.InterNetwork && GenuineUtility.LocalSystemSupportsIPv6)
+			if ((bool)this.ITransportContext.IParameterProvider[GenuineParameter.TcpDualSocketMode] &&
+                addressFamily == AddressFamily.InterNetwork && GenuineUtility.LocalSystemSupportsIPv6)
 				addressFamily = AddressFamily.InterNetworkV6;
 
 			// start socket listening
@@ -2342,12 +2343,13 @@ namespace Belikov.GenuineChannels.GenuineTcp
 				LingerOption lingerOption = new LingerOption(true, 3);
 				socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, lingerOption);
 
-				// setup port sharing: share the port (other apps can use the same one):
-				//TODO: discuss, if this should be an properties entry controlled behavior?
-				//socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+                // setup port sharing: share the port (other apps can use the same one):
+			    if ((bool)this.ITransportContext.IParameterProvider[GenuineParameter.TcpReuseAddressPort])
+                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
 
-				// setup dual listener mode, if IPv6 and IPv4 running at the same time.
-				if (addressFamily == AddressFamily.InterNetworkV6 && GenuineUtility.LocalSystemSupportsIPv6)
+                // setup dual listener mode, if IPv6 and IPv4 running at the same time.
+                if ((bool)this.ITransportContext.IParameterProvider[GenuineParameter.TcpDualSocketMode] &&
+                    addressFamily == AddressFamily.InterNetworkV6 && GenuineUtility.LocalSystemSupportsIPv6)
 				{
 					// Set dual-mode (IPv4 & IPv6) for the socket listener (Vista and Longhorn above only).
 					// 27 is equivalent to IPV6_V6ONLY socket option in the winsock snippet below,

--- a/Genuine Channels/Sources/Parameters/DefaultParameterProvider.cs
+++ b/Genuine Channels/Sources/Parameters/DefaultParameterProvider.cs
@@ -57,6 +57,8 @@ namespace Belikov.GenuineChannels.Parameters
 			this._readParameters[(int) GenuineParameter.TcpPreventDelayedAck] = false;
 			this._readParameters[(int) GenuineParameter.TcpReceiveBufferSize] = -1;
 			this._readParameters[(int) GenuineParameter.TcpSendBufferSize] = -1;
+			this._readParameters[(int) GenuineParameter.TcpReuseAddressPort] = false;
+			this._readParameters[(int) GenuineParameter.TcpDualSocketMode] = true;
 
 			// Shared memory
 			this._readParameters[(int) GenuineParameter.SMShareSize] = 300000;

--- a/Genuine Channels/Sources/Parameters/GenuineParameter.cs
+++ b/Genuine Channels/Sources/Parameters/GenuineParameter.cs
@@ -166,14 +166,27 @@ namespace Belikov.GenuineChannels.Parameters
 		/// </summary>
 		TcpSendBufferSize,
 
-		#endregion
+        /// <summary>
+        /// [BOOL] Indicates whether to use TCP port sharing. If set the listener port will be shared (other apps can use the same one).
+        /// In this case the socket option <seealso cref="System.Net.Sockets.SocketOptionName.ReuseAddress"/> will be applied.
+        /// Default value is false.
+        /// </summary>
+        TcpReuseAddressPort,
 
-		#region -- Shared memory -------------------------------------------------------------------
+        /// <summary>
+        /// [BOOL] The TCP dual socket mode will enable both IPv4 and IPv6 for the socket listener (Vista and Longhorn above only).
+        /// This will be true by default. If you like to force IPv4 or IPv6 listening only, set this option to false.
+        /// </summary>
+        TcpDualSocketMode,
 
-		/// <summary>
-		/// [INT] Size of the share in bytes.
-		/// </summary>
-		SMShareSize,
+        #endregion
+
+        #region -- Shared memory -------------------------------------------------------------------
+
+        /// <summary>
+        /// [INT] Size of the share in bytes.
+        /// </summary>
+        SMShareSize,
 
 		/// <summary>
 		/// [TimeSpan] The maximum time span within which the message must be completely received by a remote host.

--- a/Genuine Channels/Tests/GenuineChannels.UnitTests.csproj
+++ b/Genuine Channels/Tests/GenuineChannels.UnitTests.csproj
@@ -41,10 +41,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="UnitTests\GenuineUtilityTests.cs" />
+    <Compile Include="UnitTests\GtcpIPv6Tests.cs" />
+    <Compile Include="UnitTests\GtcpLocalhostTests.cs" />
     <Compile Include="UnitTests\GtcpTests.cs" />
     <Compile Include="UnitTests\GxhttpTests.cs" />
     <Compile Include="UnitTests\RegressionTests.cs" />
     <Compile Include="UnitTests\AssemblyInfo.cs" />
+    <Compile Include="UnitTests\RemoteServerTestBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sources\GenuineChannels.Desktop.v4.6.csproj">

--- a/Genuine Channels/Tests/GenuineChannels.UnitTests.v3.5.csproj
+++ b/Genuine Channels/Tests/GenuineChannels.UnitTests.v3.5.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E2804967-610D-47C5-1D30-83DB8F61394F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GenuineChannels.UnitTests</RootNamespace>
+    <AssemblyName>GenuineChannels.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\DLL\UnitTests35\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;FRM20</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\DLL\UnitTests35\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTests\GenuineUtilityTests.cs" />
+    <Compile Include="UnitTests\GtcpIPv6Tests.cs" />
+    <Compile Include="UnitTests\GtcpLocalhostTests.cs" />
+    <Compile Include="UnitTests\GtcpTests.cs" />
+    <Compile Include="UnitTests\GxhttpTests.cs" />
+    <Compile Include="UnitTests\RegressionTests.cs" />
+    <Compile Include="UnitTests\AssemblyInfo.cs" />
+    <Compile Include="UnitTests\RemoteServerTestBase.cs" />
+    <Compile Include="UnitTests\Support\Tuple.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Sources\GenuineChannels.Desktop.v3.5.csproj">
+      <Project>{002F15BE-46E6-47E9-8317-660A0D3CEA3E}</Project>
+      <Name>GenuineChannels.Desktop.v3.5</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Genuine Channels/Tests/GenuineChannels.UnitTests.v4.6.csproj
+++ b/Genuine Channels/Tests/GenuineChannels.UnitTests.v4.6.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\DLL\UnitTests\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRM20;FRM40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/Genuine Channels/Tests/UnitTests/AssemblyInfo.cs
+++ b/Genuine Channels/Tests/UnitTests/AssemblyInfo.cs
@@ -15,8 +15,12 @@ using System.Security;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: AllowPartiallyTrustedCallers]
+#if FRM40
+//
+// NOTE: This attribute is only available in .NET Framework 4.0 or higher.
+//
 [assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level1)]
-
+#endif
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Genuine Channels/Tests/UnitTests/GenuineUtilityTests.cs
+++ b/Genuine Channels/Tests/UnitTests/GenuineUtilityTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Belikov.GenuineChannels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GenuineChannels.UnitTests.UnitTests
+{
+	[TestClass]
+	public class GenuineUtilityTests
+	{
+		[TestMethod]
+		public void Localhost_Resolves2IPv6()
+		{
+			var he = Dns.GetHostEntry("localhost");
+			Console.WriteLine("localhost: {0}", he.AddressList[0]);
+		}
+
+		[TestMethod]
+		public void SplitToHostAndPort_HostNames()
+		{
+			var testDict = new Dictionary<string, Tuple<string, int>>
+			{
+				{ "gtcp://localhost:1235", new Tuple<string, int>("localhost", 1235)},
+				{ "gtcp://myserver:1236", new Tuple<string, int>("myserver", 1236)},
+				{ "gtcp://server.domain.com:1237", new Tuple<string, int>("server.domain.com", 1237)},
+				{ "gtcp://localhost:1235/subdomain", new Tuple<string, int>("localhost", 1235)},
+				{ "gtcp://myserver:1236/a/b/c", new Tuple<string, int>("myserver", 1236)},
+				{ "gtcp://server.domain.com:1237/default.aspx", new Tuple<string, int>("server.domain.com", 1237)}
+			};
+
+			RunSplitToHostAndPortWithInputDictionary(testDict);
+		}
+
+		[TestMethod]
+		public void SplitToHostAndPort_IPv4()
+		{
+			var testDict = new Dictionary<string,Tuple<string,int>>
+			{
+				{ "gtcp://127.0.0.1:1234", new Tuple<string, int>("127.0.0.1", 1234)},
+				{ "gtcp://198.11.34.2:1235", new Tuple<string, int>("198.11.34.2", 1235)},
+				{ "gtcp://127.0.0.1:1234/subdomain", new Tuple<string, int>("127.0.0.1", 1234)},
+				{ "gtcp://198.11.34.2:1235/a/b/c", new Tuple<string, int>("198.11.34.2", 1235)}
+			};
+
+			RunSplitToHostAndPortWithInputDictionary(testDict);
+		}
+
+		[TestMethod]
+		public void SplitToHostAndPort_IPv6()
+		{
+			var testDict = new Dictionary<string, Tuple<string, int>>
+			{
+				{ "gtcp://::1:1233", new Tuple<string, int>("::1", 1233)},
+				{ "gtcp://fec0:0:0:ffff::1:1234", new Tuple<string, int>("fec0:0:0:ffff::1", 1234)},
+				{ "gtcp://fec0:0:0:ffff::1%1:1235", new Tuple<string, int>("fec0:0:0:ffff::1%1", 1235)},
+				{ "gtcp://fe80::1d2b:147c:c69a:26ef%30:1236", new Tuple<string, int>("fe80::1d2b:147c:c69a:26ef%30", 1236)},
+				{ "gtcp://::1", new Tuple<string, int>("::1", 0)},
+				{ "gtcp://fec0:0:0:ffff::1%1", new Tuple<string, int>("fec0:0:0:ffff::1%1", 0)},
+				{ "gtcp://fe80::1d2b:147c:c69a:26ef%30", new Tuple<string, int>("fe80::1d2b:147c:c69a:26ef%30", 0)},
+				{ "gtcp://::1:1233/subdomain", new Tuple<string, int>("::1", 1233)},
+				{ "gtcp://fec0:0:0:ffff::1:1234/a/b/c", new Tuple<string, int>("fec0:0:0:ffff::1", 1234)},
+				{ "gtcp://fec0:0:0:ffff::1%1:1235/index.rem", new Tuple<string, int>("fec0:0:0:ffff::1%1", 1235)},
+				{ "gtcp://fe80::1d2b:147c:c69a:26ef%30:1236/service", new Tuple<string, int>("fe80::1d2b:147c:c69a:26ef%30", 1236)},
+				{ "gtcp://::1/myservices", new Tuple<string, int>("::1", 0)},
+				{ "gtcp://fec0:0:0:ffff::1%1/a/b/c", new Tuple<string, int>("fec0:0:0:ffff::1%1", 0)},
+				{ "gtcp://fe80::1d2b:147c:c69a:26ef%30/index.rem", new Tuple<string, int>("fe80::1d2b:147c:c69a:26ef%30", 0)}
+			};
+
+			RunSplitToHostAndPortWithInputDictionary(testDict);
+		}
+
+		private static void RunSplitToHostAndPortWithInputDictionary(Dictionary<string, Tuple<string, int>> testDict)
+		{
+			foreach (var entry in testDict)
+			{
+				try
+				{
+					int port;
+					Assert.AreEqual(entry.Value.Item1, GenuineUtility.SplitToHostAndPort(entry.Key, out port), true,
+						"-> Host name of Entry Key: {0}", entry.Key);
+					Assert.AreEqual(entry.Value.Item2, port, "-> Port of Entry Key: {0}", entry.Key);
+				}
+				catch (Exception ex)
+				{
+					Assert.Fail("{0}: {1} -> Port of Entry Key: {2}", ex.GetType().Name, ex.Message, entry.Key);
+				}
+			}
+		}
+	}
+}

--- a/Genuine Channels/Tests/UnitTests/GtcpIPv6Tests.cs
+++ b/Genuine Channels/Tests/UnitTests/GtcpIPv6Tests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Belikov.GenuineChannels.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GenuineChannels.UnitTests.UnitTests
+{
+	[TestClass]
+	public class GtcpIPv6Tests: RemoteServerTestBase
+	{
+		#region Test Setup
+
+		public GtcpIPv6Tests()
+			: base(GcChannelType.GTCP, () => new Service(), IpVersion.IPv6)
+		{
+		} 
+		#endregion
+
+		#region Service def.
+
+		internal class Service : MarshalByRefObject, IService
+		{
+			public string Greeting(string s)
+			{
+				var result = $"Hello, {s}!";
+				Console.WriteLine("Replying to client: {0}", result);
+				return result;
+			}
+		}
+
+		public interface IService
+		{
+			string Greeting(string s);
+		} 
+		#endregion
+
+		[TestMethod]
+		public void RemoteInvocation()
+		{
+			var proxy = (IService) Activator.GetObject(typeof(IService), ServiceUri); 
+			var greeting = proxy.Greeting("World");
+
+			Assert.AreEqual("Hello, World!", greeting);
+		}
+
+		[TestMethod]
+		public void RemoteInvocationWithPostfix()
+		{
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUriRem);
+			var greeting = proxy.Greeting("World");
+
+			Assert.AreEqual("Hello, World!", greeting);
+		}
+
+		[TestMethod]
+		public void RemoteInvocationWithCompression()
+		{
+			// test compression
+			var parameters = new SecuritySessionParameters(
+				SecuritySessionServices.DefaultContext.Name,
+				SecuritySessionAttributes.EnableCompression,
+				TimeSpan.FromSeconds(5));
+
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUri); 
+
+			using (new SecurityContextKeeper(parameters))
+			{
+				var greeting = proxy.Greeting("Compressed World");
+				Assert.AreEqual("Hello, Compressed World!", greeting);
+			}
+		}
+
+		[TestMethod]
+		public void RemoteInvocationWithCompressionAndPostfix()
+		{
+			// test compression
+			var parameters = new SecuritySessionParameters(
+				SecuritySessionServices.DefaultContext.Name,
+				SecuritySessionAttributes.EnableCompression,
+				TimeSpan.FromSeconds(5));
+
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUriRem);
+
+			using (new SecurityContextKeeper(parameters))
+			{
+				var greeting = proxy.Greeting("Compressed World");
+				Assert.AreEqual("Hello, Compressed World!", greeting);
+			}
+		}
+	}
+}

--- a/Genuine Channels/Tests/UnitTests/GtcpLocalhostTests.cs
+++ b/Genuine Channels/Tests/UnitTests/GtcpLocalhostTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Belikov.GenuineChannels.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GenuineChannels.UnitTests.UnitTests
+{
+	[TestClass]
+	public class GtcpLocalhostTests: RemoteServerTestBase
+	{
+
+		#region Test Setup
+		public GtcpLocalhostTests()
+			: base(GcChannelType.GTCP, () => new Service(), IpVersion.IPv4)
+		{
+		}
+
+		protected override string ServiceAddress => "localhost";	// !!! This IS under test here. Should work for both IPv4 systems, and IPv6, incl. Dual stack systems
+		protected override int Port => 8731;
+
+		#endregion
+
+		#region Service def.
+
+		internal class Service : MarshalByRefObject, IService
+		{
+			public string Greeting(string s)
+			{
+				var result = $"Hello, {s}!";
+				Console.WriteLine("Replying to client: {0}", result);
+				return result;
+			}
+		}
+
+		public interface IService
+		{
+			string Greeting(string s);
+		} 
+
+		#endregion
+
+		[TestMethod]
+		public void RemoteInvocation()
+		{
+			// note: localhost url should now work, although it may be resolved to IPv6 address
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUri);
+			var greeting = proxy.Greeting("World");
+
+			Assert.AreEqual("Hello, World!", greeting);
+		}
+
+		[TestMethod]
+		public void RemoteInvocationWithPostfix()
+		{
+			// note: localhost url should now work, although it may be resolved to IPv6 address
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUriRem);
+			var greeting = proxy.Greeting("World");
+
+			Assert.AreEqual("Hello, World!", greeting);
+		}
+
+		[TestMethod]
+		public void RemoteInvocationWithCompression()
+		{
+			// test compression
+			var parameters = new SecuritySessionParameters(
+				SecuritySessionServices.DefaultContext.Name,
+				SecuritySessionAttributes.EnableCompression,
+				TimeSpan.FromSeconds(5));
+
+			// note: localhost url should now work, although it may be resolved to IPv6 address
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUri);
+
+			using (new SecurityContextKeeper(parameters))
+			{
+				var greeting = proxy.Greeting("Compressed World");
+				Assert.AreEqual("Hello, Compressed World!", greeting);
+			}
+		}
+
+		[TestMethod]
+		public void RemoteInvocationWithCompressionAndPostfix()
+		{
+			// test compression
+			var parameters = new SecuritySessionParameters(
+				SecuritySessionServices.DefaultContext.Name,
+				SecuritySessionAttributes.EnableCompression,
+				TimeSpan.FromSeconds(5));
+
+			// note: localhost url should now work, although it may be resolved to IPv6 address
+			var proxy = (IService)Activator.GetObject(typeof(IService), ServiceUriRem);
+
+			using (new SecurityContextKeeper(parameters))
+			{
+				var greeting = proxy.Greeting("Compressed World");
+				Assert.AreEqual("Hello, Compressed World!", greeting);
+			}
+		}
+	}
+}

--- a/Genuine Channels/Tests/UnitTests/GtcpTests.cs
+++ b/Genuine Channels/Tests/UnitTests/GtcpTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Text;
-using System.Threading.Tasks;
 using Belikov.GenuineChannels;
 using Belikov.GenuineChannels.Connection;
 using Belikov.GenuineChannels.GenuineTcp;

--- a/Genuine Channels/Tests/UnitTests/GxhttpTests.cs
+++ b/Genuine Channels/Tests/UnitTests/GxhttpTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Text;
-using System.Threading.Tasks;
 using Belikov.GenuineChannels;
 using Belikov.GenuineChannels.Connection;
 using Belikov.GenuineChannels.GenuineTcp;

--- a/Genuine Channels/Tests/UnitTests/RegressionTests.cs
+++ b/Genuine Channels/Tests/UnitTests/RegressionTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Text;
-using System.Threading.Tasks;
 using Belikov.GenuineChannels.GenuineTcp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/Genuine Channels/Tests/UnitTests/RemoteServerTestBase.cs
+++ b/Genuine Channels/Tests/UnitTests/RemoteServerTestBase.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Remoting;
+using System.Runtime.Remoting.Channels;
+using Belikov.GenuineChannels.GenuineTcp;
+using Belikov.GenuineChannels.GenuineXHttp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GenuineChannels.UnitTests.UnitTests
+{
+	public enum GcChannelType
+	{
+		GTCP,
+		GHTTP
+	}
+
+	public enum IpVersion
+	{
+		IPv4,
+		IPv6
+	}
+
+	public abstract class RemoteServerTestBase
+	{
+		private readonly GcChannelType _channelType;
+		private readonly IpVersion _ipVersion;
+		private readonly Func<MarshalByRefObject> _serviceInstanceCreatorFunction;
+
+		protected RemoteServerTestBase(GcChannelType channelType, Func<MarshalByRefObject> serviceInstanceCreatorFunction, IpVersion ipVersion = IpVersion.IPv4)
+		{
+			_channelType = channelType;
+			_ipVersion = ipVersion;
+			if (serviceInstanceCreatorFunction == null)
+				throw new ArgumentNullException(nameof(serviceInstanceCreatorFunction));
+			_serviceInstanceCreatorFunction = serviceInstanceCreatorFunction;
+		}
+
+		protected virtual string ServiceName => GetType().Name;
+		protected virtual string ServiceNameRemPostfixed => string.Format("{0}.rem", ServiceName);
+		protected virtual string GcChannelName => GcUriScheme;
+		protected virtual int Port => 8737;
+		protected virtual string ListenerInterface => _ipVersion == IpVersion.IPv4 ? null : "::1"; // IPv4: "0.0.0.0" to be reachable within local network / default
+		protected virtual int Priority => 100;
+		protected virtual string ServiceAddress => _ipVersion == IpVersion.IPv4
+			? System.Net.IPAddress.Loopback.ToString()
+			: System.Net.IPAddress.IPv6Loopback.ToString();
+
+
+		protected string ServiceUri => string.Format("{0}/{1}", ServiceUriBase, ServiceName);
+		protected string ServiceUriRem => string.Format("{0}/{1}", ServiceUriBase, ServiceNameRemPostfixed);
+
+	
+		/// <summary>
+		/// Starts the server. Runs for every test method.
+		/// </summary>
+		[TestInitialize]
+		public void StartServer()
+		{
+			ServerChannel = RegisterChannel(server: true);
+
+			if (!string.IsNullOrEmpty(ServiceName))
+			{
+				ServiceObj = GuardedCreateService();
+				ServiceObjRef = RemotingServices.Marshal(ServiceObj, ServiceName);
+			}
+			if (!string.IsNullOrEmpty(ServiceNameRemPostfixed))
+			{
+				ServiceWithPostfixObj = GuardedCreateService();
+				ServiceWithPostfixObjRef = RemotingServices.Marshal(ServiceWithPostfixObj, ServiceNameRemPostfixed);
+			}
+		}
+
+		/// <summary>
+		/// Stops the server. Runs for every test method.
+		/// </summary>
+		[TestCleanup]
+		public void StopServer()
+		{
+			if (ServiceObj != null)
+			{
+				RemotingServices.Unmarshal(ServiceObjRef);
+				RemotingServices.Disconnect(ServiceObj);
+			}
+			if (ServiceWithPostfixObj != null)
+			{
+				RemotingServices.Unmarshal(ServiceWithPostfixObjRef);
+				RemotingServices.Disconnect(ServiceWithPostfixObj);
+			}
+
+			ChannelServices.UnregisterChannel(ServerChannel);
+
+			ServiceObj = null;
+			ServiceWithPostfixObj = null;
+			ServerChannel = null;
+		}
+
+	
+		private string ServiceUriBase => string.Format("{0}://{1}:{2}", GcUriScheme, ServiceAddress, Port);
+		private IChannel ServerChannel { get; set; }
+		private MarshalByRefObject ServiceObj { get; set; }
+		private MarshalByRefObject ServiceWithPostfixObj { get; set; }
+		private ObjRef ServiceObjRef { get; set; }
+		private ObjRef ServiceWithPostfixObjRef { get; set; }
+		
+		
+		private string GcUriScheme
+		{
+			get
+			{
+				switch (_channelType)
+				{
+					case GcChannelType.GHTTP: return "ghttp";
+					case GcChannelType.GTCP: return "gtcp";
+					default: throw new NotImplementedException(_channelType.ToString());
+				}
+			}
+		}
+
+		private IChannel RegisterChannel(bool server = false)
+		{
+			var props = new Dictionary<string, string>
+			{
+				{ "name", GcChannelName },
+				{ "priority", Priority.ToString() }
+			};
+
+			if (server)
+			{
+				props["port"] = Port.ToString();
+				if (!string.IsNullOrEmpty(ListenerInterface))
+					props["interface"] = ListenerInterface;
+			}
+
+			IChannel channel;
+			switch (_channelType)
+			{
+				case GcChannelType.GHTTP: channel = new GenuineXHttpChannel(props, null, null);
+					break;
+				case GcChannelType.GTCP: channel = new GenuineTcpChannel(props, null, null);
+					break;
+				default: throw new NotImplementedException(_channelType.ToString());
+			}
+			
+			ChannelServices.RegisterChannel(channel, false);
+			return channel;
+		}
+
+		private MarshalByRefObject GuardedCreateService()
+		{
+			var service = _serviceInstanceCreatorFunction();
+			if (service == null)
+				throw new InvalidOperationException("Service creator function MUST return a service instance");
+			return service;
+		}
+	}
+}

--- a/Genuine Channels/Tests/UnitTests/Support/Tuple.cs
+++ b/Genuine Channels/Tests/UnitTests/Support/Tuple.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+// keep namespace
+// ReSharper disable once CheckNamespace
+namespace System
+{
+    static class Tuple
+    {
+        public static Tuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2)
+        {
+            return new Tuple<T1, T2>(item1, item2);
+        }
+    }
+
+    [DebuggerDisplay("Item1={Item1};Item2={Item2}")]
+    class Tuple<T1, T2> : IFormattable
+    {
+        public T1 Item1 { get; private set; }
+        public T2 Item2 { get; private set; }
+
+        public Tuple(T1 item1, T2 item2)
+        {
+            Item1 = item1;
+            Item2 = item2;
+        }
+
+        #region Optional - If you need to use in dictionaries or check equality
+        private static readonly IEqualityComparer<T1> Item1Comparer = EqualityComparer<T1>.Default;
+        private static readonly IEqualityComparer<T2> Item2Comparer = EqualityComparer<T2>.Default;
+
+        public override int GetHashCode()
+        {
+            var hc = 0;
+            if (!object.ReferenceEquals(Item1, null))
+                hc = Item1Comparer.GetHashCode(Item1);
+            if (!object.ReferenceEquals(Item2, null))
+                hc = (hc << 3) ^ Item2Comparer.GetHashCode(Item2);
+            return hc;
+        }
+        public override bool Equals(object obj)
+        {
+            var other = obj as Tuple<T1, T2>;
+            if (object.ReferenceEquals(other, null))
+                return false;
+            else
+                return Item1Comparer.Equals(Item1, other.Item1) && Item2Comparer.Equals(Item2, other.Item2);
+        }
+        #endregion
+
+        #region Optional - If you need to do string-based formatting
+        public override string ToString() { return ToString(null, CultureInfo.CurrentCulture); }
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return string.Format(formatProvider, format ?? "{0},{1}", Item1, Item2);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
My public visible changes are described within the [Changelog](https://github.com/netsrotr/GenuineChannels/blob/master/CHANGELOG.md). 
Further I added a new unit test project targeting .NET v3.5, and a new unit test base class to simplify writing new unit tests.